### PR TITLE
Remove commit information from branch output

### DIFF
--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -25,7 +25,6 @@ type Branch struct {
 	Type        BranchType
 	Name        string
 	Description string
-	LastCommit  string
 }
 
 // NewBranch constructs a new Branch structure based on the given branch. The branch name must
@@ -34,13 +33,11 @@ type Branch struct {
 func NewBranch(name string) (*Branch, error) {
 	branchType, name := determineBranchType(name)
 	desc := getBranchDescription(name)
-	lastCommit := getLastCommit(name)
 
 	return &Branch{
 		Type:        branchType,
 		Name:        name,
 		Description: desc,
-		LastCommit:  lastCommit,
 	}, nil
 }
 
@@ -94,19 +91,6 @@ func getBranchDescription(name string) string {
 
 	// Git returns a non-zero exit code if the branch does not have a description, so I am relying
 	// on the exit code instead of the returned error.
-	if cmd.ProcessState.ExitCode() != 0 {
-		return ""
-	}
-
-	return strings.TrimSpace(string(stdout))
-}
-
-func getLastCommit(branch string) string {
-	cmd := exec.Command("git", "log", "-1", "--format=format:[%h] %s (%ah)", branch)
-	stdout, _ := cmd.Output()
-
-	// Git returns a non-zero exit code if the branch does not have a commit, so I am relying on
-	// the exit code instead of the returned error.
 	if cmd.ProcessState.ExitCode() != 0 {
 		return ""
 	}

--- a/main.go
+++ b/main.go
@@ -15,9 +15,8 @@ type branchStyle struct {
 }
 
 var (
-	descStyle   = color.New(color.FgWhite)
-	commitStyle = color.New(color.Italic, color.FgWhite)
-	nameStyles  = map[git.BranchType]branchStyle{
+	descStyle  = color.New(color.FgWhite)
+	nameStyles = map[git.BranchType]branchStyle{
 		git.BranchTypeNormal:   {prefix: "  ", Color: color.New(color.Bold, color.FgWhite)},
 		git.BranchTypeCurrent:  {prefix: "* ", Color: color.New(color.Bold, color.FgGreen)},
 		git.BranchTypeWorktree: {prefix: "+ ", Color: color.New(color.Bold, color.FgCyan)},
@@ -34,22 +33,19 @@ func main() {
 		log.Fatal("An error occured when querying for branches:", err)
 	}
 
-	lastIndex := len(branches) - 1
-	for i, branch := range branches {
+	for _, branch := range branches {
 		nameStyle, ok := nameStyles[branch.Type]
 		if !ok {
 			log.Fatalf("No style is available for branch type %q", branch.Type)
 		}
 
-		nameStyle.Printf("%s%s", nameStyle.prefix, branch.Name)
-		if branch.Description != "" {
-			descStyle.Printf(" (%s)", branch.Description)
+		name := nameStyle.Sprint(nameStyle.prefix, branch.Name)
+		desc := branch.Description
+		if desc != "" {
+			fmt.Printf("%s (%s)\n", name, descStyle.Sprint(desc))
+			continue
 		}
-		commitStyle.Printf("\n    %s\n", branch.LastCommit)
 
-		// Add some spacing between branches
-		if i != lastIndex {
-			fmt.Println()
-		}
+		fmt.Println(name)
 	}
 }


### PR DESCRIPTION
Originally I thought this would be useful, but it really just seems to add a ton of clutter that isn't really necessary. If commit info *is* needed in the future maybe it can be implemented as an optional flag or config, but showing the branch, type, and description by default seems like it should be good for 99% of calls.